### PR TITLE
img.x replacement

### DIFF
--- a/src/image-zoom.directive.ts
+++ b/src/image-zoom.directive.ts
@@ -226,7 +226,7 @@ export class ImageZoom implements OnInit, OnDestroy, OnChanges {
     }
 
     private calculateOffsets() {
-        this._elementPosX = this.img.x;
+        this._elementPosX = this.img.getBoundingClientRect().left;
         this._elementPosY = this.img.y;
         if(this.lensHeight > this.img.height) {
             this.lensHeight = this.img.height;
@@ -318,7 +318,7 @@ export class ImageZoom implements OnInit, OnDestroy, OnChanges {
     public onMouseleave(event: MouseEvent) {
         let x: number = event.clientX;
         let y: number = event.clientY;
-        if(y <= this.img.y || y >= (this.img.y + this.img.height) || x <= this.img.x || x >= (this.img.x + this.img.width)) {
+        if(y <= this.img.y || y >= (this.img.y + this.img.height) || x <= this.img.getBoundingClientRect().left || x >= (this.img.getBoundingClientRect().left + this.img.width)) {
             if(this._mouseEnterDebounce !== 0) {
                 clearTimeout(this._mouseEnterDebounce);
             }

--- a/src/image-zoom.directive.ts
+++ b/src/image-zoom.directive.ts
@@ -227,7 +227,7 @@ export class ImageZoom implements OnInit, OnDestroy, OnChanges {
 
     private calculateOffsets() {
         this._elementPosX = this.img.getBoundingClientRect().left;
-        this._elementPosY = this.img.y;
+        this._elementPosY = this.img.getBoundingClientRect().top;
         if(this.lensHeight > this.img.height) {
             this.lensHeight = this.img.height;
         }
@@ -318,7 +318,7 @@ export class ImageZoom implements OnInit, OnDestroy, OnChanges {
     public onMouseleave(event: MouseEvent) {
         let x: number = event.clientX;
         let y: number = event.clientY;
-        if(y <= this.img.y || y >= (this.img.y + this.img.height) || x <= this.img.getBoundingClientRect().left || x >= (this.img.getBoundingClientRect().left + this.img.width)) {
+        if(y <= this.img.getBoundingClientRect().top || y >= (this.img.getBoundingClientRect().top + this.img.height) || x <= this.img.getBoundingClientRect().left || x >= (this.img.getBoundingClientRect().left + this.img.width)) {
             if(this._mouseEnterDebounce !== 0) {
                 clearTimeout(this._mouseEnterDebounce);
             }


### PR DESCRIPTION
I noticed a problem on Firefox with the placement of the zoom window (windowPosition 12).
I found out that the problem occurred because img.x on Firefox delivers different values than on Safari or Chrome. The usage of .getBoundingClientRect().left can be used on all 3 browsers with equal values. I changed img.y to .getBoundingClientRect().top for consistency.